### PR TITLE
Change victory conditions to account for new rule

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -181,9 +181,9 @@ const CamelotGame = Game({
 
             if (countBlackPieces <= 1 && countWhitePieces <= 1) { // DRAWWWWW
                 ctx.events.endGame({ winner: false });
-            } else if (countBlackPieces <= 1) {
+            } else if (countBlackPieces < 1 && countWhitePieces >= 2) {
                 ctx.events.endGame({ winner: "0" });
-            } else if (countWhitePieces <= 1) {
+            } else if (countWhitePieces < 1 && countBlackPieces >= 2) {
                 ctx.events.endGame({ winner: "1" });
             }
         },


### PR DESCRIPTION
I changed the "onTurnEnd" function in src/Game.js to follow the revised rule: if a player wins by capturing, he must capture all of the opponent's pieces and have two or more of his own pieces left.

After making the change, I tested the game several times. Here are the results:
**Scenario 1:** Black captured all white pieces with 8 pieces remaining (GAME OVER! Black wins!)
**Scenario 2:** White captured all black pieces with 4 pieces remaining (GAME OVER! White wins!)
**Scenario 3:** White captured all black pieces with 1 piece remaining (GAME OVER! It's a draw!)

As far as I can tell, the game is running smoothly with the new change in effect. :)

This fixes issue #5.
